### PR TITLE
Fixes by lfeldman

### DIFF
--- a/examples/quick_start/variables.tf
+++ b/examples/quick_start/variables.tf
@@ -73,7 +73,8 @@ variable "plugins" {
 }
 
 variable "jenkins_version" {
-  default = "2.138.2"
+#  default = "2.138.2"
+  default = "2.249.1"
 }
 
 variable "jenkins_password" {

--- a/modules/jenkins-master/scripts/setup.sh
+++ b/modules/jenkins-master/scripts/setup.sh
@@ -46,7 +46,7 @@ sleep 10
 waitForJenkins
 
 # INSTALL CLI
-sudo cp /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar /var/lib/jenkins/jenkins-cli.jar
+sudo wget -P /var/lib/jenkins/ http://localhost:8080/jnlpJars/jenkins-cli.jar
 
 sleep 10
 
@@ -64,7 +64,7 @@ sudo service jenkins restart
 
 waitForJenkins
 
-sleep 10
+sleep 30
 
 # INSTALL PLUGINS
 sudo java -jar /var/lib/jenkins/jenkins-cli.jar -s http://localhost:${http_port} -auth admin:$PASS install-plugin ${plugins}

--- a/variables.tf
+++ b/variables.tf
@@ -106,7 +106,7 @@ variable "jnlp_port" {
 }
 
 variable "plugins" {
-  type        = "list"
+  type        = list
   description = "A list of Jenkins plugins to install, use short names. "
   default     = ["git", "ssh-slaves", "oracle-cloud-infrastructure-compute"]
 }


### PR DESCRIPTION
I have re-tested the quick-start example and I have encountered a few bugs. This PR has fixed my problems:

1. Outdated version of Jenkins has broken Terraform execution. Have changed to higher.
2. Replaced the cp command for jenkins-cli.jar with local wget command. Only this has worked fine for me.
3. Enlarged sleep value to 30 seconds after Jenkins restart and password change (10 seconds resulted in authorization error).
4. To disable warnings in higher versions of Terraform I have removed double-quotes for the list.

Hope you will merge it with the master branch.

Best,

Luke