### PR TITLE
Set Number of "controller" executors to 0

### DIFF
--- a/modules/jenkins-controller/scripts/disable-controller-executor.groovy
+++ b/modules/jenkins-controller/scripts/disable-controller-executor.groovy
@@ -1,0 +1,5 @@
+import jenkins.model.*
+
+def instance = Jenkins.getInstance()
+instance.setNumExecutors(0)
+instance.save()

--- a/modules/jenkins-controller/scripts/setup.sh
+++ b/modules/jenkins-controller/scripts/setup.sh
@@ -68,6 +68,7 @@ export PASS=${jenkins_password}
 
 sudo -u jenkins mkdir -p /var/lib/jenkins/init.groovy.d
 sudo mv /home/opc/default-user.groovy /var/lib/jenkins/init.groovy.d/default-user.groovy
+sudo mv /home/opc/disable-controller-executor.groovy /var/lib/jenkins/init.groovy.d/disable-controller-executor.groovy
 
 restartAndWaitForJenkins
 


### PR DESCRIPTION
* Added logic to prevent the controller to be used as job executors following recommendation: https://www.jenkins.io/doc/book/security/controller-isolation/
 
Before/After change screenshot:
![screenshot](https://gist.githubusercontent.com/lucassrg/43babad8a317f03d6fc4300d43c37c43/raw/c5ffb5dc0db43091b80e4e1afe0bc3870ab3cdb7/controller-executor.png)